### PR TITLE
Checks the connection with mongodb during health check

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -20,7 +20,10 @@ app.use(restify.bodyParser());
 app.use(cors());
 
 app.get('/_health', (req, res) => {
-  return res.send(200, { ok: true });
+  if (mongoose.connection.readyState) {
+    return res.send(200, { ok: true });
+  }
+  return res.send(500, { ok: false });
 });
 
 app.get('/reports/:geolocation', reportsController.show);


### PR DESCRIPTION
The current health check was always returning an `ok` status. Now it also checks if it can connect to the configured mongodb instance.